### PR TITLE
Mass update

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      
+
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -27,7 +27,5 @@ jobs:
       - name: Run cargo clippy
         run: cargo clippy
 
-	- name: Check formatting
-	  run: cargo fmt --check
-  
-  
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+name: Standard CI
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo test
+        run: cargo test
+
+      - name: Run cargo clippy
+        run: cargo clippy
+
+	- name: Check formatting
+	  run: cargo fmt --check
+  
+  

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,7 +1,4 @@
-on:
-  push:
-    branches:
-      - master
+on: push
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 # `EffectCell`
 
 A container that runs an effect every time its data is mutated.
-The effect is run with the old data.
-
-You can mutate an `EffectCell` using the `update` method or the ~fancy~
-`cell <<= val` syntax.
-
-`EffectCell` does is also `#![no_std]`!
+In essence, a slimed down implementation of the Observer pattern using Rust's `Fn` trait.
 
 ```rust
 use effect_cell::EffectCell;
 
 fn main() {
-    let mut counter = 0;
-    let mut printer = EffectCell::new(0, |_| counter += 1);
-    printer <<= 2; // counter increments
-    printer <<= 4; // counter increments
-    assert_eq!(counter, 2)
+    let mut effect_cell = EffectCell::new(0);
+    effect_cell.bind(|data| {println!("{data}");});
+    effect_cell.update(1);
+    // Prints "1"
+}
+```
+
+## Operator Passthrough
+
+The `XAssign` traits have been setup so that they can modify the internal data
+without the need for a call through `update_lambda`.
+They will always call effects.
+
+```rust
+use effect_cell::EffectCell;
+
+fn main() {
+    let mut effect_cell = EffectCell::new(0);
+    effect_cell.bind(|data| {println!("{data}");});
+    effect_cell += 1;
+    // Prints "1"
 }
 ```
 
@@ -24,12 +35,12 @@ fn main() {
 
 Licensed under either of
 
--   Apache License, Version 2.0
-    ([LICENSE-APACHE](https://github.com/fprasx/peapod/blob/main/LICENSE-APACHE)
-    or http://www.apache.org/licenses/LICENSE-2.0)
--   MIT license
-    ([LICENSE-MIT](https://github.com/fprasx/peapod/blob/main/LICENSE-MIT) or
-    http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0
+  ([LICENSE-APACHE](https://github.com/fprasx/peapod/blob/main/LICENSE-APACHE)
+  or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license
+  ([LICENSE-MIT](https://github.com/fprasx/peapod/blob/main/LICENSE-MIT) or
+  http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,132 +1,418 @@
-#![no_std]
-use core::ops::{Index, IndexMut, ShlAssign};
+#![doc = include_str!("../README.md")]
+use core::fmt::Debug;
+use core::ops::{
+    AddAssign, BitAndAssign, BitOrAssign, BitXorAssign, DivAssign, MulAssign, RemAssign, ShlAssign,
+    ShrAssign, SubAssign,
+};
 
-/// A container that runs an effect every time its data is mutated.
-/// The effect is run with the old data.
+/// A container that runs one or many effects on data mutation.
+/// The effect is run after data is updated as per the conventions of the Observer data structure.
 ///
-/// You can mutate an `EffectCell` using the `update` method or the ~fancy~
-/// `cell <<= val` syntax.
-///
-/// `EffectCell` does is also `#![no_std]`!
+/// # Examples
 ///
 /// ```
-/// # use effect_cell::EffectCell;
-/// let mut printer = EffectCell::new(1, |x| println!("{}", x));
-/// printer <<= 2; // Prints the old data, 1
-/// printer <<= 4; // Prints the old data, 2
-/// printer.consume(); // Prints 4, consumes the EffectCell
-/// ```
+/// use effect_cell::EffectCell;
 ///
-/// Note: dropping does not execute the effect on the contained value, for this
-/// behaviour, use `consume`
-pub struct EffectCell<T, E: FnMut(&T)>
-where
-    E: FnMut(&T),
-{
+/// let mut effect_cell = EffectCell::new(0);
+/// effect_cell.bind(|data| { println!("{data}"); });
+/// effect_cell.update(2);
+/// ```
+pub struct EffectCell<T> {
     data: T,
-    effect: E,
+    effects: Vec<Box<dyn FnMut(&T)>>,
 }
 
-impl<T, E> EffectCell<T, E>
-where
-    E: FnMut(&T),
-{
-    /// Create a new `EffectCell` with the provided data and effect.
-    pub fn new(t: T, effect: E) -> Self {
-        Self { data: t, effect }
+impl<T> EffectCell<T> {
+    /// Create a new [`EffectCell`] with the provided data.
+    pub fn new(data: T) -> Self {
+        Self {
+            data,
+            effects: Vec::new(),
+        }
     }
 
-    /// Run the effect on the current data.
-    pub fn call(&mut self) {
-        (self.effect)(&self.data)
-    }
-
-    /// Consume the `EffectCell` and perform the effect using the current data.
-    /// This may be useful since dropping the `EffectCell` does not perform the
-    /// effect.
-    pub fn consume(mut self) {
-        self.call()
-    }
-
-    /// Return the stored data.
+    /// Returns the stored data.
     pub fn into_inner(self) -> T {
         self.data
     }
 
-    /// Update the inner value and run the effect using the old value
-    /// 
-    /// You can also update an `EffectCell` using `<<=`.
-    /// ```
-    /// # use effect_cell::EffectCell;
-    /// let mut updates = 0;
-    /// let mut fxl = EffectCell::new(0, |_| updates += 1);
-    /// fxl <<= 1;
-    /// assert_eq!(updates, 1);
-    /// ```
-    pub fn update(&mut self, new: T) {
-        *self <<= new;
+    /// Binds a new effect callback to the [`EffectCell`]
+    pub fn bind<F: FnMut(&T) + 'static>(&mut self, effect: F) {
+        self.effects.push(Box::new(effect));
     }
 
-    /// Update the inner value without running the effect.
+    /// Runs all effects with the current data.
+    pub fn call(&mut self) {
+        for f in &mut self.effects {
+            f(&self.data);
+        }
+    }
+
+    /// Consume the [`EffectCell`] and performs all effects using the current data.
+    /// This may be useful since dropping the [`EffectCell`] does not perform
+    /// effects.
+    pub fn consume(mut self) {
+        self.call();
+    }
+
+    /// Updates the inner value and runs the effects with the new value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use effect_cell::EffectCell;
+    ///
+    /// let mut effect_cell = EffectCell::new(0);
+    /// effect_cell.bind(|data| { println!("{data}"); });
+    /// effect_cell.update(2);
+    /// ```
+    pub fn update(&mut self, new: T) {
+        self.data = new;
+        self.call();
+    }
+
+    /// Updates the inner value using the provided function and runs the effects with the new value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use effect_cell::EffectCell;
+    ///
+    /// let mut effect_cell = EffectCell::new(0);
+    /// effect_cell.bind(|data| { println!("{data}"); });
+    /// effect_cell.update_lambda(|data| *data += 1);
+    ///
+    /// assert_eq!(effect_cell.into_inner(), 1);
+    /// ```
+    pub fn update_lambda<F: FnMut(&mut T) + 'static>(&mut self, mut lambda: F) {
+        lambda(&mut self.data);
+        self.call();
+    }
+
+    /// Updates the inner value without running any effects
     pub fn set(&mut self, new: T) {
         self.data = new;
     }
-}
 
-impl<T, E> Index<()> for EffectCell<T, E>
-where
-    E: FnMut(&T),
-{
-    type Output = T;
-
-    fn index(&self, _: ()) -> &Self::Output {
-        &self.data
+    /// Updates the inner value using the provided function without running any effects
+    pub fn set_lambda<F: FnMut(&T) + 'static>(&mut self, mut lambda: F) {
+        lambda(&mut self.data);
     }
 }
 
-impl<T, E> Clone for EffectCell<T, E>
+impl<T> PartialEq for EffectCell<T>
 where
-    E: FnMut(&T) + Clone,
-    T: Clone,
+    T: PartialEq,
 {
-    fn clone(&self) -> Self {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl<T> PartialEq<T> for EffectCell<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        &self.data == other
+    }
+}
+
+impl<T> PartialOrd for EffectCell<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.data.partial_cmp(&other.data)
+    }
+}
+
+impl<T> PartialOrd<T> for EffectCell<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        self.data.partial_cmp(other)
+    }
+}
+
+impl<T: Debug> Debug for EffectCell<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EffectCell")
+            .field("data", &self.data)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A container that runs one or many effects on data mutation.
+/// Effects are run either before or after data is updated depending on their [`EffectOrder`]
+///
+/// # Examples
+///
+/// ```
+/// # fn main() {
+/// use effect_cell::OrderedEffectCell;
+/// use effect_cell::EffectOrder;
+///
+/// let mut ordered_effect_cell = OrderedEffectCell::new(0);
+/// ordered_effect_cell.bind(
+///     EffectOrder::Prior,
+///     |data| { println!("Value before: {data}"); }
+/// );
+/// ordered_effect_cell.bind(
+///     EffectOrder::Post,
+///     |data| { println!("Value after: {data}"); }
+/// );
+/// ordered_effect_cell.update(2);
+///
+/// // Prints the following:
+/// // Value before: 0
+/// // Value after: 2
+/// # }
+/// ```
+pub struct OrderedEffectCell<T> {
+    data: T,
+    prior_effects: Vec<Box<dyn FnMut(&T)>>,
+    post_effects: Vec<Box<dyn FnMut(&T)>>,
+}
+
+impl<T> OrderedEffectCell<T> {
+    /// Create a new [`OrderedEffectCell`] with the provided data.
+    pub fn new(data: T) -> Self {
         Self {
-            data: self.data.clone(),
-            effect: self.effect.clone(),
+            data,
+            prior_effects: Vec::new(),
+            post_effects: Vec::new(),
+        }
+    }
+
+    /// Returns the stored data.
+    pub fn into_inner(self) -> T {
+        self.data
+    }
+
+    /// Binds a new effect callback to [`OrderedEffectCell`] based on the given [`EffectOrder`]
+    pub fn bind<F: FnMut(&T) + 'static>(&mut self, ord: EffectOrder, effect: F) {
+        match ord {
+            EffectOrder::Prior => {
+                self.prior_effects.push(Box::new(effect));
+            }
+            EffectOrder::Post => {
+                self.post_effects.push(Box::new(effect));
+            }
+        }
+    }
+
+    /// Runs all effects of the given [`EffectOrder`]
+    pub fn call(&mut self, ord: EffectOrder) {
+        match ord {
+            EffectOrder::Prior => {
+                for f in &mut self.prior_effects {
+                    f(&self.data);
+                }
+            }
+            EffectOrder::Post => {
+                for f in &mut self.post_effects {
+                    f(&self.data);
+                }
+            }
+        }
+    }
+
+    /// Consume the [`OrderedEffectCell`] and performs all effects using the current data.
+    /// This may be useful since dropping the [`OrderedEffectCell`] does not perform
+    /// effects.
+    ///
+    /// Both `Prior` and `Post` effects are called.
+    pub fn consume(mut self) {
+        self.call(EffectOrder::Prior);
+        self.call(EffectOrder::Post);
+    }
+
+    /// Updates inner value and runs effects with either the new or old value dependent on their
+    /// [`EffectOrder`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use effect_cell::OrderedEffectCell;
+    /// use effect_cell::EffectOrder;
+    ///
+    /// let mut ordered_effect_cell = OrderedEffectCell::new(0);
+    /// ordered_effect_cell.bind(
+    ///     EffectOrder::Prior,
+    ///     |data| { println!("Value before: {data}"); }
+    /// );
+    /// ordered_effect_cell.bind(
+    ///     EffectOrder::Post,
+    ///     |data| { println!("Value after: {data}"); }
+    /// );
+    /// ordered_effect_cell.update(2);
+    ///
+    /// // Prints the following:
+    /// // Value before: 0
+    /// // Value after: 2
+    /// ```
+    pub fn update(&mut self, new: T) {
+        self.call(EffectOrder::Prior);
+        self.data = new;
+        self.call(EffectOrder::Post);
+    }
+
+    /// Updates inner value using the provided function and runs effects with either the new or
+    /// old value dependent on their [`EffectOrder`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use effect_cell::OrderedEffectCell;
+    /// use effect_cell::EffectOrder;
+    ///
+    /// let mut ordered_effect_cell = OrderedEffectCell::new(0);
+    /// ordered_effect_cell.bind(
+    ///     EffectOrder::Prior,
+    ///     |data| { println!("Value before: {data}"); }
+    /// );
+    /// ordered_effect_cell.bind(
+    ///     EffectOrder::Post,
+    ///     |data| { println!("Value after: {data}"); }
+    /// );
+    /// ordered_effect_cell.update_lambda(|data| *data += 1);
+    ///
+    /// // Prints the following:
+    /// // Value before: 0
+    /// // Value after: 1
+    ///
+    /// assert_eq!(ordered_effect_cell.into_inner(), 1);
+    /// ```
+    pub fn update_lambda<F: FnMut(&mut T) + 'static>(&mut self, mut lambda: F) {
+        self.call(EffectOrder::Prior);
+        lambda(&mut self.data);
+        self.call(EffectOrder::Post);
+    }
+
+    /// Updates the inner value without running any effects
+    pub fn set(&mut self, new: T) {
+        self.data = new;
+    }
+
+    /// Updates the inner value using the provided function without running any effects
+    pub fn set_lambda<F: FnMut(&T) + 'static>(&mut self, mut lambda: F) {
+        lambda(&mut self.data);
+    }
+}
+
+impl<T> PartialEq for OrderedEffectCell<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
+impl<T> PartialEq<T> for OrderedEffectCell<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &T) -> bool {
+        &self.data == other
+    }
+}
+
+impl<T> PartialOrd for OrderedEffectCell<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.data.partial_cmp(&other.data)
+    }
+}
+
+impl<T> PartialOrd<T> for OrderedEffectCell<T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        self.data.partial_cmp(other)
+    }
+}
+
+impl<T: Debug> Debug for OrderedEffectCell<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OrderedEffectCell")
+            .field("data", &self.data)
+            .finish_non_exhaustive()
+    }
+}
+
+macro_rules! impl_pass_op {
+    ($struct_name:ty, $trait:path, $trait_name:path, $fn_name:ident, $op:tt) => {
+        impl<T> $trait for $struct_name
+        where
+            T: $trait_name,
+        {
+            fn $fn_name(&mut self, other: T) {
+                self.data $op other;
+                self.call()
+            }
         }
     }
 }
 
-impl<T, E> IndexMut<()> for EffectCell<T, E>
-where
-    E: FnMut(&T),
-{
-    fn index_mut(&mut self, _: ()) -> &mut Self::Output {
-        (self.effect)(&self.data);
-        &mut self.data
+macro_rules! impl_pass_op_ord {
+    ($struct_name:ty, $trait:path, $trait_name:path, $fn_name:ident, $op:tt) => {
+        impl<T> $trait for $struct_name
+        where
+            T: $trait_name,
+        {
+            fn $fn_name(&mut self, other: T) {
+                self.call(EffectOrder::Prior);
+                self.data $op other;
+                self.call(EffectOrder::Post);
+            }
+        }
     }
 }
 
-impl<T, E> ShlAssign<T> for EffectCell<T, E>
-where
-    E: FnMut(&T),
-{
-    fn shl_assign(&mut self, rhs: T) {
-        self.call();
-        self.data = rhs;
-    }
+macro_rules! impl_struct_pass {
+    ($struct_name:ty) => {
+        impl_pass_op!($struct_name, AddAssign<T>, AddAssign, add_assign, +=);
+        impl_pass_op!($struct_name, SubAssign<T>, SubAssign, sub_assign, -=);
+        impl_pass_op!($struct_name, MulAssign<T>, MulAssign, mul_assign, *=);
+        impl_pass_op!($struct_name, DivAssign<T>, DivAssign, div_assign, /=);
+        impl_pass_op!($struct_name, RemAssign<T>, RemAssign, rem_assign, %=);
+        impl_pass_op!($struct_name, ShlAssign<T>, ShlAssign, shl_assign, <<=);
+        impl_pass_op!($struct_name, ShrAssign<T>, ShrAssign, shr_assign, >>=);
+        impl_pass_op!($struct_name, BitAndAssign<T>, BitAndAssign, bitand_assign, &=);
+        impl_pass_op!($struct_name, BitOrAssign<T>, BitOrAssign, bitor_assign, |=);
+        impl_pass_op!($struct_name, BitXorAssign<T>, BitXorAssign, bitxor_assign, ^=);
+    };
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+macro_rules! impl_struct_pass_ord {
+    ($struct_name:ty) => {
+        impl_pass_op_ord!($struct_name, AddAssign<T>, AddAssign, add_assign, +=);
+        impl_pass_op_ord!($struct_name, SubAssign<T>, SubAssign, sub_assign, -=);
+        impl_pass_op_ord!($struct_name, MulAssign<T>, MulAssign, mul_assign, *=);
+        impl_pass_op_ord!($struct_name, DivAssign<T>, DivAssign, div_assign, /=);
+        impl_pass_op_ord!($struct_name, RemAssign<T>, RemAssign, rem_assign, %=);
+        impl_pass_op_ord!($struct_name, ShlAssign<T>, ShlAssign, shl_assign, <<=);
+        impl_pass_op_ord!($struct_name, ShrAssign<T>, ShrAssign, shr_assign, >>=);
+        impl_pass_op_ord!($struct_name, BitAndAssign<T>, BitAndAssign, bitand_assign, &=);
+        impl_pass_op_ord!($struct_name, BitOrAssign<T>, BitOrAssign, bitor_assign, |=);
+        impl_pass_op_ord!($struct_name, BitXorAssign<T>, BitXorAssign, bitxor_assign, ^=);
+    };
+}
 
-    #[test]
-    fn effect_not_run_on_drop() {
-        let mut counter = 0;
-        let fxl = EffectCell::new(0, |_| counter += 1);
-        #[allow(clippy::drop_non_drop)]
-        drop(fxl);
-        assert_eq!(counter, 0)
-    }
+impl_struct_pass!(EffectCell<T>);
+impl_struct_pass_ord!(OrderedEffectCell<T>);
+
+/// Represents whether an effect should be called before or after data is updated
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EffectOrder {
+    /// Represents the ordering of an effect that should be called before data is updated
+    Prior,
+    /// Represents the ordering of an effect the should be called after data is updated
+    Post,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use core::ops::{
 
 /// A container that runs one or many effects on data mutation.
 /// The effect is run after data is updated as per the conventions of the Observer data structure.
+/// Effects are run in the order that they were bound to [`EffectCell`] in.
 ///
 /// # Examples
 ///
@@ -146,6 +147,7 @@ impl<T: Debug> Debug for EffectCell<T> {
 
 /// A container that runs one or many effects on data mutation.
 /// Effects are run either before or after data is updated depending on their [`EffectOrder`]
+/// Effects are run in the order that they were bound to each [`EffectOrder`] in [`OrderedEffectCell`].
 ///
 /// # Examples
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,0 @@
-use effect_cell::EffectCell;
-
-fn main() {
-    let mut counter = 0;
-    let mut printer = EffectCell::new(0, |_| counter += 1);
-    printer <<= 2; // counter increments
-    printer <<= 4; // counter increments
-    assert_eq!(counter, 2)
-}


### PR DESCRIPTION
Changes:
- New type `OrderedEffectCell` with `EffectOrder`
- Full documentation + doctests
- Operator passthrough
- Custom `Debug` impls
- `update_lambda` and `set_lambda`
- Update README with new examples for features
- Github Actions for CI testing
- No longer `no_std` due to requirement of `Vec` for multiple effect bindings

Note: There is a lot changed so the git diffs look like a mess