### PR TITLE
Bump version number in preparation for crates.io update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-authors = ["Felix Prasanna <fpx@mit.edu>"] 
+authors = ["Felix Prasanna <fpx@mit.edu>"]
 description = "Container that runs effects when updated"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/effect_cell"
 readme = "README.md"
 name = "effect_cell"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/fprasx/effect-cell"
 homepage = "https://github.com/fprasx/effect-cell"


### PR DESCRIPTION
With all of the changes that have occurred in the repo as of recent, it seems appropriate to update the crate on `crates.io`.
This push just updates the version number, @fprasx will have to make the update on their own machine.
Also consider placing a new release on GitHub for consistency.